### PR TITLE
Concurrency fix on the parser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ I decided to experiment TDD using ```Midje``` instead of ```clojure.test``` for 
 - [Aleph](https://github.com/ztellman/aleph)
 - [Compojure-API](https://github.com/metosin/compojure-api)
 
+## Other resources
+- [Langohr on heroku](https://devcenter.heroku.com/articles/queuing-in-clojure-with-langohr-and-rabbitmq)
+- [Heroku & Docker (beta)](https://blog.heroku.com/archives/2015/5/5/introducing_heroku_docker_release_build_deploy_heroku_apps_with_docker)
 <br>
 
 

--- a/dev-resources/config.edn
+++ b/dev-resources/config.edn
@@ -1,7 +1,9 @@
 {:config
- {:bus {:bus-conf {:buffer-size 1 :buffer-type :sliding}
-        :pub-type-conf {:buffer-size 1 :buffer-type :sliding}}
-  :parser {:parse-sub-conf {:buffer-size 1 :buffer-type :sliding}}
+ {:bus {:bus-conf {:buffer-size 1 :buffer-type :dropping}
+        :pub-type-parse-conf {:buffer-size 1 :buffer-type :dropping}
+        :pub-type-data-conf {:buffer-size 1 :buffer-type :dropping}}
+  :parser {:parse-sub-conf {:buffer-size 1 :buffer-type :dropping}
+           :parse-timeout 20000}
   :searcher {:data-sub-conf {:buffer-size 1 :buffer-type :dropping}
              :locations [{:type :resource-file
                           :resource-path "enwiki-20150515-abstract24.xml"}]}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wiki_search_xml "0.3.0-SNAPSHOT"
+(defproject wiki_search_xml "0.4.0-SNAPSHOT"
   :description "A text search app within wikipedia xml abstract files"
   :url "https://github.com/arichiardi/wiki-search-xml"
   :license {:name "Eclipse Public License"
@@ -33,6 +33,7 @@
   :jvm-opts ^:replace ["-Dclojure.assert-if-lazy-seq=true"]
   :plugins [[lein-environ "1.0.0"]
             [lein-pprint "1.1.2"]]
+  :min-lein-version "2.0.0"
   :aliases {"bg-repl" ["trampoline" "repl" ":headless" "> repl.out 2> repl.err < /dev/null &"]}
   :profiles {:uberjar {:aot :all
                        :main wiki_search_xml.daemon}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,7 +1,8 @@
 {:config
- {:version "0.3.0-SNAPSHOT"
+ {:version "0.4.0-SNAPSHOT"
   :bus {:bus-conf {:buffer-size 100 :buffer-type :sliding}
-        :pub-type-conf {:buffer-size 100 :buffer-type :sliding}}
+        :pub-type-parse-conf {:buffer-size 100 :buffer-type :dropping}
+        :pub-type-data-conf {:buffer-size 100 :buffer-type :dropping}}
   :parser {:parse-sub-conf {:buffer-size 100 :buffer-type :sliding}}
   :searcher {:data-sub-conf {:buffer-size 100 :buffer-type :dropping}
              :locations [{:type :resource-file

--- a/src/wiki_search_xml/parser.clj
+++ b/src/wiki_search_xml/parser.clj
@@ -1,12 +1,13 @@
 (ns wiki-search-xml.parser
-  (:require [com.stuartsierra.component :as component]
+  (:require [clojure.tools.trace :refer [deftrace trace] :rename {trace t}]
+            [com.stuartsierra.component :as component]
             [clojure.core.async :as async]
             [clojure.tools.logging :as log]
             [wiki-search-xml.bus :refer [subscribe]]
             [wiki-search-xml.fetch :refer [fetch]]
             [wiki-search-xml.core :as core]
             [wiki-search-xml.common :as common]
-            [wiki-search-xml.parse.impl :as parse]))
+            [wiki-search-xml.parse.impl :as p]))
 
 (declare consume!)
 
@@ -15,27 +16,27 @@
                    ;; dependecies
                    bus
                    ;; state
-                   sub-parse parsed-locations]
+                   sub-parse parse-data-cache]
   component/Lifecycle
   (stop [this]
     ;; unsubscribe
-    (if sub-parse 
+    (if sub-parse
       (do (async/close! sub-parse)
           (-> this
               (assoc :sub-parse nil)
-              (assoc :parsed-cache nil)))
+              (assoc :parse-data-cache nil)))
       this))
-  
+
   (start [this]
     (if sub-parse
       this
       (let [c (async/chan (common/conf->buffer parse-sub-conf))
             sp (subscribe bus :parse c)
             component (-> this (assoc :sub-parse sp)
-                               (assoc :parsed-cache (atom nil)))]
+                               (assoc :parse-data-cache (atom nil)))]
         (core/<!-do-loop! sp (partial consume! component))
         component))))
-  
+
 (defn new-parser [config]
   "Creates an instance of a document fetcher, it accepts a map of additional key/values to be added
   to the request map"
@@ -46,45 +47,78 @@
 ;;; parse ;;;
 ;;;;;;;;;;;;;
 
-(defn parse-stream-async
-  "Asynchronously parse the FetchResult coming from channel.
+(defn- ^:testable
+  fetch-and-parse!
+  "Synchronously and blocking parse and fetch from location.
   The output depends on the format of the parsing function, which now
-  corresponds to parse/wiki-*->trie-pair. Value hook modifies the
-  value payload before insertion and is tipically used to assoc some
-  db-specific fields."
-  [value-hook fetch-channel]
-  (async/thread (let [{:keys [stream error]} (async/<!! fetch-channel)]
-                  (log/debugf "fetch-result ready (payload not displayed but error was: %s)" error)
-                  (if stream 
-                    {:data (parse/wiki-source->trie-pair value-hook stream)}
-                    {:error error}))))
+  corresponds to parse/wiki-*->trie-pair. Value-hook modifies the value
+  payload before insertion and is tipically used to assoc some
+  db-specific fields. Returns a channel that will contains a map
+  with :data and :error or nil if id does not make sense to recover from
+  errors."
+  [value-hook location]
+  (async/thread
+    (when-let [fetch-result (async/<!! (fetch location))]
+      (let [{:keys [stream error]} fetch-result]
+        (log/debugf "fetch-result ready (payload not displayed but error was: %s)" error)
+        (if stream
+          {:data (p/wiki-source->trie-pair value-hook stream)}
+          {:error error})))))
 
-(defn parse-location
+(defn- ensure-location-in-cache
+  [old-cache location]
+  (if-let [loc (get old-cache location)]
+    old-cache
+    (assoc old-cache location (atom (p/empty-data)))))
+
+(defn- ^:testable
+  parse-location!
+  "Asynchronously parses the location and updates the parser data cache
+  as side effect. Returns the new data for the location. It returns a
+  chann4el with the result."
+  [parser location]
+  (async/go
+    (log/debug "processing location" location)
+
+    (let [{:keys [parse-data-cache]} parser
+          pd (get @parse-data-cache location)]
+      (if (and (p/parsed? pd) (not (p/error? pd)))
+        (do (log/debug "already parsed, returning cached value") 
+            (p/result pd))
+        (do (swap! parse-data-cache ensure-location-in-cache location)
+            ;; point of sync
+            (let [cached-pd (get @parse-data-cache location)
+                  altered-pd (swap! cached-pd p/update-parse-state)
+                  result (if (p/parsed? altered-pd)
+                           (p/result altered-pd)
+                           (do
+                             (when (p/parsing? altered-pd)
+                               (do (log/debug "parsing and writing results")
+                                   (async/pipe (fetch-and-parse! identity location)
+                                               (p/write-channel altered-pd))))
+                             (async/<! (p/read-channel altered-pd))))]
+              (log/debugf "location parsed (error was: %s)" (or (:error result) "-"))
+              (swap! parse-data-cache assoc location (p/data->parsed result))
+              result))))))
+
+
+(defn- ^:testable
+  msg->parsed!
   "Parses a location, returning a channel that will yield a
   core/msg->DataMsg with class :parsed-xml whose data is the result of
   either fetching or just returning the parsed document according to the
   location found in the input msg."
-  [this msg]
-  (let [{:keys [parsed-cache]} this
-        {:keys [location]} msg]
-    (log/debug "parsing location" location)
-
-    (async/go
+  [parser msg]
+  (async/go
+    (let [{:keys [location]} msg]
       (core/msg->DataMsg msg
-                         (merge {:class :parsed-xml} 
-                                (if-let [parsed (get @parsed-cache location)]
-                                  {:data parsed}
-                                  (let [parsed (async/<! (parse-stream-async identity (fetch location)))]
-                                    (log/debugf "location parsed (error was: %s)" (:error parsed))
-                                    (when-let [data (:data parsed)]
-                                      (swap! parsed-cache assoc location data))
-                                    parsed)))))))
+                         (merge {:class :parsed-xml}
+                                (async/<! (parse-location! parser location)))))))
 
 (defn consume!
   "Consumes the input message."
-  [this msg]
-  (let [chan (get-in this [:bus :chan] this)]
-    (case (:type msg) 
-      :parse (async/go (let [parsed (async/<! (parse-location this msg))]
-                         (async/>! chan parsed)))
+  [parser msg]
+  (let [chan (get-in parser [:bus :chan])]
+    (case (:type msg)
+      :parse (async/pipe (msg->parsed! parser msg) chan false)
       (log/debug "message is not for me"))))

--- a/src/wiki_search_xml/server/handler.clj
+++ b/src/wiki_search_xml/server/handler.clj
@@ -60,10 +60,10 @@
         key (get-in req [:query-params "q"])
         timeout-ch (async/timeout 20000)
         results (let [[res ch] (async/alts!! [(search/search-for searcher (string/lower-case key)) 
-                                                   timeout-ch] :priority true)]
-                       (if-not (= ch timeout-ch)
-                         {:results (or (:search-results res) [])} ;; TODO better error handling
-                         {:results []}))]
+                                              timeout-ch] :priority true)]
+                  (if-not (= ch timeout-ch)
+                    {:results (or (:search-results res) [])} 
+                    {:results []}))] ;; TODO better error handling
     (log/debugf "search key was %s -> generated json contains %s results" key (count (:results results))) 
     {:body (assoc results :q key)}))
 

--- a/test/wiki_search_xml/parse/t_impl.clj
+++ b/test/wiki_search_xml/parse/t_impl.clj
@@ -87,7 +87,7 @@
     #_(spit "dump.trie" file-trie)
 
     (let [docs (->> xml-string xml/parse-str :content (filter #(= :doc (:tag %))))]
-      (doseq [doc (conj (take 200 docs) (first docs) (last docs))]
+      (doseq [doc (conj (take 100 docs) (first docs) (last docs))]
         (let [zipped-doc (zip/xml-zip doc)
               title (xml-text zipped-doc :title)
               abstract (xml-text zipped-doc :abstract)

--- a/test/wiki_search_xml/t_core.clj
+++ b/test/wiki_search_xml/t_core.clj
@@ -2,9 +2,9 @@
   (:require [wiki-search-xml.core :refer :all]
             [midje.sweet :refer :all]
             [wiki-search-xml.common :as common]
-            [clojure.core.async :refer [chan go <! <!! >! >!! timeout]]))
+            [clojure.core.async :refer [chan go <! <!! >! >!! timeout pub sub]]))
 
-(fact "about `core`"
+(facts "about `core`"
 
   (fact "`<t!!` return the right value or times out"
     (let [c1 (chan)]
@@ -12,6 +12,37 @@
       (do (go (do (<! (timeout 500)) (>! c1  "test"))) (<t!! c1 1000)) => "test"
       (do (go (do (<! (timeout 2000)) (>! c1  "test"))) (<t!! c1 1000)) => timeout-msg
       (<t!! c1 10) => timeout-msg))
+
+  (fact "<!-do-loop! "
+    (let [ch1 (chan 1)
+          a (atom 0)]
+      (<!-do-loop! ch1 (swap! a inc))
+      @a => 1))
+
+  (fact "<!-do-loop! correctly executes side effect more than once "
+    (let [ch1 (chan 1)
+          a (atom 0)]
+      (<!-do-loop! ch1 (fn [_] (swap! a inc)))
+      (>!! ch1 "1")
+      (>!! ch1 "2")
+      (>!! ch1 "3")
+      (>!! ch1 "4")
+      @a => 4))
+
+  (future-fact "<!-do-loop! correctly skips msgs if channel is a sub"
+    (let [ch1 (chan 6)
+          p1 (pub ch1 :target)
+          s1 (chan 6)
+          _ (sub p1 :me s1)
+          a (atom 0)]
+      (<!-do-loop! s1 (fn [_] (swap! a inc)))
+      (>!! ch1 {:target :me})
+      (>!! ch1 {:target :you})
+      (>!! ch1 {:target :her})
+      (>!! ch1 {:target :me})
+      (>!! ch1 {:target :them})
+      (>!! ch1 {:target :me})
+      @a => 3))
 
   (fact ">!-dispatch-<!-apply! correctly dispatches on the first chan"
     (let [ch1 (chan 1)
@@ -23,9 +54,9 @@
     (let [ch1 (chan 1)
           ch2 (chan 1)
           out (>!-dispatch-<!-apply! ch1 ch2
-                         #(= :test (:what %1))
-                         #(assoc % :success true)
-                         {:what :dispatch})]
+                                     #(= :test (:what %1))
+                                     #(assoc % :success true)
+                                     {:what :dispatch})]
       (go (>! ch2 {:what :test}))
       (<t!! out 250) => (just {:what :test :success true})))
 
@@ -33,9 +64,9 @@
     (let [ch1 (chan 1)
           ch2 (chan 1)
           out (>!-dispatch-<!-apply! ch1 ch2
-                         #(= :test (:what %1))
-                         #(assoc % :success true)
-                         {:what :dispatch})]
+                                     #(= :test (:what %1))
+                                     #(assoc % :success true)
+                                     {:what :dispatch})]
 
       (go (>! ch2 {:what :not-for-me}))
       (<t!! out 250) => timeout-msg))
@@ -44,20 +75,16 @@
     (let [ch1 (chan 1)
           ch2 (chan 2)
           out (>!-dispatch-<!-apply! ch1 ch2
-                         #(= :test (:what %1))
-                         #(assoc % :success true)
-                         {:what :dispatch})]
+                                     #(= :test (:what %1))
+                                     #(assoc % :success true)
+                                     {:what :dispatch})]
 
       (go (>! ch2 {:what :not-for-me})
           (<! (timeout 500))
           (>! ch2 {:what :test}))
       (<t!! out 750) => (just {:what :test :success true})))
 
-  
-  )
-
-
-(fact "<t-shut! if receiving within timeout everything is fine"
+  (fact "<t-shut! if receiving within timeout everything is fine"
     (let [ch1 (chan 1)
           out (<t-shut! ch1 500)]
 
@@ -65,12 +92,14 @@
           (>! ch1 {:what :test}))
       (<t!! out 550) => (just {:what :test})))
 
-(fact "<t-shut! if receiving after timeout is triggered channel is closed (returns nil)"
-  (let [ch1 (chan 1)
-        out (<t-shut! ch1 100)]
-    (<!! (timeout 500))
-    (>!! ch1 {:what :test}) => false
-    (<t!! ch1 250) => nil
-    (<t!! ch1 250) => nil
-    (<t!! ch1 250) => nil))
+  (fact "<t-shut! if receiving after timeout is triggered channel is closed (returns nil)"
+    (let [ch1 (chan 1)
+          out (<t-shut! ch1 100)]
+      (<!! (timeout 500))
+      (>!! ch1 {:what :test}) => false
+      (<t!! ch1 250) => nil
+      (<t!! ch1 250) => nil
+      (<t!! ch1 250) => nil)))
+
+
 

--- a/test/wiki_search_xml/t_parser.clj
+++ b/test/wiki_search_xml/t_parser.clj
@@ -1,10 +1,14 @@
 (ns wiki-search-xml.t-parser
-  (:require [clojure.core.async :refer [go >! >!!]]
+  (:require [clojure.tools.trace :refer [deftrace trace] :rename {trace t}]
+            [clojure.core.async :as async]
             [wiki-search-xml.parser :refer :all]
             [wiki-search-xml.system :as sys]
             [wiki-search-xml.core :as core]
             [wiki-search-xml.common :as common]
-            [midje.sweet :refer :all]))
+            [midje.sweet :refer :all]
+            [midje.util :refer [expose-testables]]))
+
+(expose-testables wiki-search-xml.parser)
 
 (facts "about `parser`"
   (let [config-map (sys/make-config)
@@ -16,7 +20,7 @@
     (fact "unstarted, should have nil dependencies and instance"
       (get-in system [:wsx-parser :sub-parse]) => nil
       (get-in system [:wsx-parser :bus]) => nil)
-    
+
     (fact "when started should have non-nil dependencies and instance"
       (common/with-component-start system
         (get-in __started__ [:wsx-parser :sub-parse]) => some?
@@ -27,19 +31,44 @@
         (get-in stopped [:wsx-parser :sub-parse]) => nil
         (get-in stopped [:wsx-parser :bus]) => nil))
 
-    (fact "parse-location should produce :parsed-xml data"
-      :slow
-      (common/with-component-start system
-        (let [parser (get-in __started__ [:wsx-parser])
-              test-location (:test-resource-location config-map)] 
-          (core/<t!! (parse-location parser {:location test-location})
-                       25000)) => (contains {:type :data :class :parsed-xml})))
+    (fact "fetch-and-parse! should produce a parsing record with filled :data"
+        :slow
+        (let [test-location (:test-resource-location config-map)]
+          (core/<t!! (fetch-and-parse! identity test-location) 30000) => (contains {:data some?})))
 
-    (fact "parse-location should produce data from cache (faster) the second time over"
+    (fact "parse-location! should not work twice but give results for all requesters"
+        :slow
+        (common/with-component-start system
+          (let [parser (get-in __started__ [:wsx-parser])
+                test-location (:test-resource-location config-map)]
+            (core/<t!! (async/reduce (fn [c _] (inc c)) 0
+                                     (async/merge [(async/go (async/<! (parse-location! parser test-location)))
+                                                   (async/go (async/<! (parse-location! parser test-location)))
+                                                   (async/go (async/<! (parse-location! parser test-location)))
+                                                   (async/go (async/<! (parse-location! parser test-location)))]))
+                       30000) => 4)))
+
+    (fact "parse-location! should produce :parsed-xml data"
+        :slow
+        (common/with-component-start system
+          (let [parser (get-in __started__ [:wsx-parser])
+                test-location (:test-resource-location config-map)]
+            (core/<t!! (parse-location! parser test-location)
+                       30000) => (contains {:data some?}))))
+
+    (fact "parse-location! should produce data from cache (faster) the second time over"
+        :slow
+        (common/with-component-start system
+          (let [parser (get-in __started__ [:wsx-parser])
+                test-location (:test-resource-location config-map)]
+            (do (core/<t!! (parse-location! parser test-location) 30000)
+                (core/<t!! (parse-location! parser test-location)
+                           500))) => (contains {:data some?})))
+
+    (fact "parse-location! should produce data from cache (faster) the second time over"
       :slow
       (common/with-component-start system
         (let [parser (get-in __started__ [:wsx-parser])
-              test-location (:test-resource-location config-map)] 
-          (do (core/<t!! (parse-location parser {:location test-location}) 45000) 
-              (core/<t!! (parse-location parser {:location test-location})
-                           500))) => (contains {:type :data :class :parsed-xml})))))
+              msg {:type :parse :location (:test-resource-location config-map)}]
+          (core/<t!! (msg->parsed! parser msg)
+                     35000) => (contains {:type :data :class :parsed-xml :data some?}))))))

--- a/test/wiki_search_xml/t_system.clj
+++ b/test/wiki_search_xml/t_system.clj
@@ -1,9 +1,8 @@
 (ns wiki-search-xml.t-system
-  (:require [clojure.pprint :refer [pprint]]
-            [wiki-search-xml.system :refer :all]
+  (:require [wiki-search-xml.system :refer :all]
             [midje.sweet :refer :all]))
 
 (facts "about `system`"
   (fact "version is matching project.clj"
     (let [system (new-system (make-config))]
-      (:wsx-version system) => "0.3.0-SNAPSHOT")))
+      (:wsx-version system) => "0.4.0-SNAPSHOT")))


### PR DESCRIPTION
Now the Parser correcly handles multiple requests of parsing of the same location from multiple
threads. Just one sub-thread parses the location and the answer is sent back on a multiple tapped
channel (the thread which parses writes on a clojure.core.async/mult).  The tests have been adjsted
accordingly and they are all green.

Version bump to 0.4.0-SNAPSHOT.
